### PR TITLE
Fix custom policies

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -141,7 +141,7 @@ resource "aws_imagebuilder_image_recipe" "main" {
   parent_image      = var.imgrep_parent_img
   description       = var.imgrep_description
   working_directory = var.imgrep_working_dir
-  user_data_base64  = base64encode(var.imgrep_user_data)
+  user_data_base64  = var.imgrep_user_data != null ? base64encode(var.imgrep_user_data) : null
   tags              = var.imgrep_tags
 
   dynamic "component" {

--- a/iam.tf
+++ b/iam.tf
@@ -12,7 +12,7 @@ resource "aws_iam_role" "main" {
   path  = "/"
 
   assume_role_policy  = file("${path.module}/policies/iam/iam_assume_role.json")
-  managed_policy_arns = var.imgb_managed_policies
+  managed_policy_arns = local.all_managed_policies
 }
 
 # Additional S3logs policy if logging is needed

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,5 @@
 locals {
   custom_policy_arns = var.imgb_custom_policy != "" && length(aws_iam_policy.custom) > 0 ? [aws_iam_policy.custom[0].arn] : []
-  all_managed_policies = concat(var.imgb_managed_policies, local.custom_policy_arns)
+  managed_policies_list = tolist(var.imgb_managed_policies)
+  all_managed_policies = concat(local.managed_policies_list, local.custom_policy_arns)
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  custom_policy_arns = var.imgb_custom_policy != "" && length(aws_iam_policy.custom) > 0 ? [aws_iam_policy.custom[0].arn] : []
+  all_managed_policies = concat(var.imgb_managed_policies, local.custom_policy_arns)
+}


### PR DESCRIPTION
## Description of the change

> Previously, custom policies would be removed when running `terragrunt apply` for the second time. This fixes it so the custom policy stays attached.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

> Link to Shortcut/Jira Ticket Goes Here

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
