### PR TITLE
Add pipeline dependency replacement

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -23,6 +23,13 @@ resource "aws_imagebuilder_image_pipeline" "main" {
     image_tests_enabled = var.imgpipe_tests_enabled
     timeout_minutes     = var.imgpipe_timeout_mins
   }
+
+# Replace the pipeline if the recipte changes due to dependencies. AWS will not allow modifying recipie without replacing pipeline
+  lifecycle {
+    replace_triggered_by = [
+      aws_imagebuilder_image_recipe.main
+    ]
+  }
 }
 
 # Conditional image creation at TF runtime


### PR DESCRIPTION
## Description of the change

> Imagebuilder module will not allow changing a recipe unless the pipeline is removed first, because it's dependency. Adding fix from [this](https://github.com/hashicorp/terraform-provider-aws/issues/39985) issue.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

> Link to Shortcut/Jira Ticket Goes Here

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
